### PR TITLE
Realm Configuration modify to support demo app

### DIFF
--- a/springboot-realm.json
+++ b/springboot-realm.json
@@ -523,7 +523,7 @@
       "secret": "**********",
       "redirectUris" : [ "http://localhost:*" ],
       "webOrigins": [
-        "http://localhost:3000"
+        "http://localhost:3000","http://activiti-cloud-demo-ui:3000"
       ],
       "notBefore": 0,
       "bearerOnly": false,


### PR DESCRIPTION
Guys, I've changed the realm configuration and I didn't want to push straight to master. But we need this to get a demo app working from a docker image. We need to figure out how to externalise the realm configuration anyway. Originally we created this image just because we need that place for storing our activiti specific configs. 